### PR TITLE
GB-315/registration-referral-code

### DIFF
--- a/app/views/services/autoform/index.html.erb
+++ b/app/views/services/autoform/index.html.erb
@@ -230,7 +230,7 @@
       <div class="alert alert-success alert-dismissible" role="alert">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true" class="success">&times;</span>
         </button>
-        <%= 'Žiadosť o registráciu bola odoslaná na schválenie. Ďakujeme za Váš záujem a budeme Vás kontaktovať. V prípade, ak by sme sa Vám v najbližších dňoch neozvali, kontaktujte nás, prosím, na <a href="mailto:ekosystem@slovensko.digital">ekosystem@slovensko.digital</a>.'.html_safe %>
+        <%= 'Registrácia bola odoslaná na schválenie. Ďakujeme za Váš záujem a budeme Vás v priebehu najbližších pracovných dní kontaktovať.' %>
       </div>
     </div>
 

--- a/app/views/services/govbox/_hidden_fields_from_step1.html.erb
+++ b/app/views/services/govbox/_hidden_fields_from_step1.html.erb
@@ -1,4 +1,4 @@
 <%= hidden_field_tag :mode, params[:mode], value: params[:mode] || 'sync_mode' %>
-<%= hidden_field_tag :referral_code, params[:referral_code] %>
+<%= hidden_field_tag :referral_code, params[:referral_code], value: params[:referral_code] || cookies[:ref] %>
 <%= hidden_field_tag :legal_subject_name, params[:legal_subject_name] %>
 <%= hidden_field_tag :cin, params[:cin] %>

--- a/app/views/services/govbox/_hidden_fields_from_step1.html.erb
+++ b/app/views/services/govbox/_hidden_fields_from_step1.html.erb
@@ -1,3 +1,4 @@
 <%= hidden_field_tag :mode, params[:mode], value: params[:mode] || 'sync_mode' %>
+<%= hidden_field_tag :referral_code, params[:referral_code] %>
 <%= hidden_field_tag :legal_subject_name, params[:legal_subject_name] %>
 <%= hidden_field_tag :cin, params[:cin] %>

--- a/app/views/services/govbox/_hidden_fields_from_step4.html.erb
+++ b/app/views/services/govbox/_hidden_fields_from_step4.html.erb
@@ -1,4 +1,3 @@
 <%= render 'hidden_fields_from_step3' %>
 <%= hidden_field_tag :password, params[:password] %>
 <%= hidden_field_tag :password_confirmation, params[:password_confirmation] %>
-<%= hidden_field_tag :referral_code, params[:referral_code] %>

--- a/app/views/services/govbox/register_step1.html.erb
+++ b/app/views/services/govbox/register_step1.html.erb
@@ -49,6 +49,7 @@
         <div class="row">
           <div class="col-md-8 form-group">
             <%= hidden_field_tag :mode, params[:mode], :value => params[:mode] || 'sync_mode' %>
+            <%= hidden_field_tag :referral_code, params[:referral_code], :value => params[:referral_code] || cookies[:ref] %>
             <%= label_tag :legal_subject_name, 'Názov právnickej osoby' %>
             <%= text_field_tag :legal_subject_name, params[:legal_subject_name], class: 'form-control input-lg', required: true, autocomplete: 'off', data: {'slovensko-digital-autoform': 'name'} %>
             <span class="form-text text-muted">Napríklad: Slovensko.Digital, Martinus</span>

--- a/app/views/services/govbox/register_step4.html.erb
+++ b/app/views/services/govbox/register_step4.html.erb
@@ -1,7 +1,6 @@
 <div class="container">
   <%= form_tag register_step5_services_govbox_index_path do %>
     <%= render 'hidden_fields_from_step3' %>
-    <%= hidden_field_tag :referral_code, cookies[:ref] %>
 
     <div class="row">
       <div class="col-md-6">


### PR DESCRIPTION
- pridal som hidden_field_tag `referral_code`, v prvom kroku registrácie, ktorý berie buď `referral_code` z `query` alebo z `cookies`
- odstránil som hidden_field_tag `referral_code` z posledného kroku registrácie